### PR TITLE
Feature/map concert list in date order

### DIFF
--- a/components/homeScreen/ConcertList.tsx
+++ b/components/homeScreen/ConcertList.tsx
@@ -23,7 +23,7 @@ export default function ConcertList({
               source={event.img}
               imageStyle={{ opacity: 0.5 }}
               style={styles.cardBackgroundImage}
-              resizeMode="stretch"
+              resizeMode="cover"
             >
               <Card.Content style={styles.cardContent}>
                 <Text style={styles.cardTitle}>{event.artist}</Text>

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -53,7 +53,13 @@ export default function HomeScreen() {
         setCurrentCity(city);
 
         const events = await searchConcertsNearYou(city, 10);
-        setNearEventList(events._embedded?.events.map(mapToConcertCard) ?? []);
+        const mappedEvents =
+          events._embedded?.events.map(mapToConcertCard) ?? [];
+        mappedEvents.sort(
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+        );
+
+        setNearEventList(mappedEvents);
       } catch {
         Alert.alert(
           "Error",


### PR DESCRIPTION
In this PR: 
1. Added sorting to nearEventList, this means that when the concerts near you are rendered, they render in order from the date closest to date farthest away.
2. Changed resizeMode to 'cover' on ImageBackground in  ConcertList. 