### PR TITLE
Feature/create-account-error-handling

### DIFF
--- a/components/forms/CreateAccountForm.tsx
+++ b/components/forms/CreateAccountForm.tsx
@@ -26,8 +26,7 @@ export default function CreateAccountForm({
   const [password, setPassword] = useState<string>("");
   const [firstname, setFirstname] = useState<string>("");
   const [surname, setSurname] = useState<string>("");
-  const { loading } = useSignin();
-  const { signUp } = useSignup();
+  const { signUp, loading } = useSignup();
 
   async function handleSignup() {
     Keyboard.dismiss();

--- a/components/forms/CreateAccountForm.tsx
+++ b/components/forms/CreateAccountForm.tsx
@@ -15,8 +15,10 @@ import { useSignup } from "../../hooks/useSignup";
 import { setUserDataFromFirebase } from "../../utils/setUserDataFromFirebase";
 
 export default function CreateAccountForm({
+  setSnackbarMsg,
   setIsSnackbarVisible
 }: {
+  setSnackbarMsg: (msg: string) => void;
   setIsSnackbarVisible: (boolean: boolean) => void;
 }) {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
@@ -32,6 +34,7 @@ export default function CreateAccountForm({
     const user = await signUp({ email, password, firstname, surname });
 
     if (!user) {
+      setSnackbarMsg("All Fields Required");
       setIsSnackbarVisible(true);
       return;
     }

--- a/components/forms/SigninForm.tsx
+++ b/components/forms/SigninForm.tsx
@@ -14,8 +14,10 @@ import { ActivityIndicator } from "react-native-paper";
 import { setUserDataFromFirebase } from "../../utils/setUserDataFromFirebase";
 
 export default function SigninForm({
+  setSnackbarMsg,
   setIsSnackbarVisible
 }: {
+  setSnackbarMsg: (msg: string) => void;
   setIsSnackbarVisible: (boolean: boolean) => void;
 }) {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
@@ -28,6 +30,7 @@ export default function SigninForm({
     const user = await signIn(email, password);
 
     if (!user) {
+      setSnackbarMsg("Wrong Credentials");
       setIsSnackbarVisible(true);
       return;
     }

--- a/hooks/useSignup.ts
+++ b/hooks/useSignup.ts
@@ -4,9 +4,14 @@ import { auth } from "../firebase/firebaseConfig";
 import { db } from "../firebase/firebaseConfig";
 import { IUser } from "../types/IUser";
 import { IUserData } from "../types/IUserData";
+import { useState } from "react";
 
 export function useSignup() {
+  const [loading, setLoading] = useState(false);
+
   const signUp = async (user: IUser) => {
+    setLoading(true);
+
     try {
       const userCredential = await createUserWithEmailAndPassword(
         auth,
@@ -25,8 +30,9 @@ export function useSignup() {
 
       return userCredential.user;
     } catch (error) {
-      console.error("Signup error:", error);
       return null;
+    } finally {
+      setLoading(false);
     }
   };
 

--- a/hooks/useSignup.ts
+++ b/hooks/useSignup.ts
@@ -36,5 +36,5 @@ export function useSignup() {
     }
   };
 
-  return { signUp };
+  return { signUp, loading };
 }

--- a/screens/CreateAccountScreen.tsx
+++ b/screens/CreateAccountScreen.tsx
@@ -15,6 +15,7 @@ import CreateAccountForm from "../components/forms/CreateAccountForm";
 export default function CreateAccountScreen() {
   const [isSnackbarVisible, setIsSnackbarVisible] = useState<boolean>(false);
   const onDismissSnackBar = () => setIsSnackbarVisible(false);
+  const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -30,7 +31,10 @@ export default function CreateAccountScreen() {
             style={styles.logo}
             resizeMode="contain"
           />
-          <CreateAccountForm setIsSnackbarVisible={setIsSnackbarVisible} />
+          <CreateAccountForm
+            setSnackbarMsg={setSnackbarMsg}
+            setIsSnackbarVisible={setIsSnackbarVisible}
+          />
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>
       <Snackbar
@@ -40,7 +44,7 @@ export default function CreateAccountScreen() {
           label: "Close"
         }}
       >
-        Wrong Credentials
+        {snackbarMsg}
       </Snackbar>
     </SafeAreaView>
   );

--- a/screens/SigninScreen.tsx
+++ b/screens/SigninScreen.tsx
@@ -15,6 +15,7 @@ import { StatusBar } from "react-native";
 export default function SigninScreen() {
   const [isSnackbarVisible, setIsSnackbarVisible] = useState<boolean>(false);
   const onDismissSnackBar = () => setIsSnackbarVisible(false);
+  const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -30,7 +31,10 @@ export default function SigninScreen() {
             style={styles.logo}
             resizeMode="contain"
           />
-          <SigninForm setIsSnackbarVisible={setIsSnackbarVisible} />
+          <SigninForm
+            setSnackbarMsg={setSnackbarMsg}
+            setIsSnackbarVisible={setIsSnackbarVisible}
+          />
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>
       <Snackbar


### PR DESCRIPTION
In this PR: 

Implemented basic error handling in the sign in and create account screens so it shows different snackbar messages depending on what screen your on.

1.  show different snackbar messages in create account and sin in screen
2. fix bug where the ActivityIndicator isn't triggered when clicking on Create account.