### PR TITLE
Refactor/set background color in navigation stack

### DIFF
--- a/navigation/navigation.tsx
+++ b/navigation/navigation.tsx
@@ -8,7 +8,12 @@ export default function RootStack() {
   const Stack = createNativeStackNavigator<RootStackParamList>();
 
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: "#061A1E" }
+      }}
+    >
       <Stack.Screen name="SigninScreen" component={SigninScreen} />
       <Stack.Screen name="HomeScreen" component={HomeScreen} />
       <Stack.Screen

--- a/screens/CreateAccountScreen.tsx
+++ b/screens/CreateAccountScreen.tsx
@@ -53,7 +53,6 @@ export default function CreateAccountScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#061A1E",
     alignItems: "center",
     justifyContent: "center",
     padding: 20

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -70,8 +70,7 @@ export default function HomeScreen() {
 
 const styles = StyleSheet.create({
   background: {
-    flex: 1,
-    backgroundColor: "#061A1E"
+    flex: 1
   },
   container: {
     flex: 1,

--- a/screens/SigninScreen.tsx
+++ b/screens/SigninScreen.tsx
@@ -53,7 +53,6 @@ export default function SigninScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#061A1E",
     justifyContent: "center",
     alignItems: "center",
     padding: 20


### PR DESCRIPTION
In this PR: 

I set a universal background color in the navigationstack. This means that there is no need to set background color on each container stylesheet in each screen.

1. set universal background color in the navigation stack
2. remove background color from all container styles in all screens