### PR TITLE
Feature/explore-all-events-screen

### DIFF
--- a/components/forms/CreateAccountForm.tsx
+++ b/components/forms/CreateAccountForm.tsx
@@ -1,5 +1,3 @@
-import { NavigationProp, useNavigation } from "@react-navigation/native";
-import { RootStackParamList } from "../../types/navigation.types";
 import { useState } from "react";
 import {
   TextInput,
@@ -12,6 +10,7 @@ import {
 import { ActivityIndicator } from "react-native-paper";
 import { useSignup } from "../../hooks/useSignup";
 import { setUserDataFromFirebase } from "../../utils/setUserDataFromFirebase";
+import UseTypeNavigation from "../../hooks/useTypeNavigation";
 
 export default function CreateAccountForm({
   setSnackbarMsg,
@@ -20,7 +19,7 @@ export default function CreateAccountForm({
   setSnackbarMsg: (msg: string) => void;
   setIsSnackbarVisible: (boolean: boolean) => void;
 }) {
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigation = UseTypeNavigation();
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const [firstname, setFirstname] = useState<string>("");

--- a/components/forms/SigninForm.tsx
+++ b/components/forms/SigninForm.tsx
@@ -1,5 +1,3 @@
-import { NavigationProp, useNavigation } from "@react-navigation/native";
-import { RootStackParamList } from "../../types/navigation.types";
 import { useState } from "react";
 import { useSignin } from "../../hooks/useSignin";
 import {
@@ -12,6 +10,7 @@ import {
 } from "react-native";
 import { ActivityIndicator } from "react-native-paper";
 import { setUserDataFromFirebase } from "../../utils/setUserDataFromFirebase";
+import UseTypeNavigation from "../../hooks/useTypeNavigation";
 
 export default function SigninForm({
   setSnackbarMsg,
@@ -20,7 +19,7 @@ export default function SigninForm({
   setSnackbarMsg: (msg: string) => void;
   setIsSnackbarVisible: (boolean: boolean) => void;
 }) {
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigation = UseTypeNavigation();
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string>("");
   const { signIn, loading } = useSignin();

--- a/components/homeScreen/ConcertList.tsx
+++ b/components/homeScreen/ConcertList.tsx
@@ -8,15 +8,14 @@ import {
 } from "react-native";
 import { Card } from "react-native-paper";
 import { IConcertCard } from "../../types/IConcertCard";
-import { NavigationProp, useNavigation } from "@react-navigation/native";
-import { RootStackParamList } from "../../types/navigation.types";
+import UseTypeNavigation from "../../hooks/useTypeNavigation";
 
 export default function ConcertList({
   concertList
 }: {
   concertList: IConcertCard[];
 }) {
-  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+  const navigation = UseTypeNavigation();
 
   return (
     <View style={styles.recommendedCard}>

--- a/components/homeScreen/ConcertList.tsx
+++ b/components/homeScreen/ConcertList.tsx
@@ -9,6 +9,7 @@ import {
 import { Card } from "react-native-paper";
 import { IConcertCard } from "../../types/IConcertCard";
 import UseTypeNavigation from "../../hooks/useTypeNavigation";
+import { UseCurrentScreenStore } from "../../stores/useCurrentScreenStore";
 
 export default function ConcertList({
   concertList
@@ -16,6 +17,7 @@ export default function ConcertList({
   concertList: IConcertCard[];
 }) {
   const navigation = UseTypeNavigation();
+  const { setCurrentScreen } = UseCurrentScreenStore();
 
   return (
     <View style={styles.recommendedCard}>
@@ -41,6 +43,7 @@ export default function ConcertList({
         style={styles.exploreButton}
         onPress={() => {
           navigation.navigate("ExploreScreen");
+          setCurrentScreen("explore");
         }}
       >
         <Text style={styles.exploreButtonText}>Explore All Events</Text>

--- a/components/homeScreen/ConcertList.tsx
+++ b/components/homeScreen/ConcertList.tsx
@@ -8,12 +8,16 @@ import {
 } from "react-native";
 import { Card } from "react-native-paper";
 import { IConcertCard } from "../../types/IConcertCard";
+import { NavigationProp, useNavigation } from "@react-navigation/native";
+import { RootStackParamList } from "../../types/navigation.types";
 
 export default function ConcertList({
   concertList
 }: {
   concertList: IConcertCard[];
 }) {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
   return (
     <View style={styles.recommendedCard}>
       <ScrollView horizontal={true}>
@@ -34,7 +38,12 @@ export default function ConcertList({
           </Card>
         ))}
       </ScrollView>
-      <TouchableOpacity style={styles.exploreButton} onPress={() => {}}>
+      <TouchableOpacity
+        style={styles.exploreButton}
+        onPress={() => {
+          navigation.navigate("ExploreScreen");
+        }}
+      >
         <Text style={styles.exploreButtonText}>Explore All Events</Text>
       </TouchableOpacity>
     </View>

--- a/components/nav-bar/BottomNavBar.tsx
+++ b/components/nav-bar/BottomNavBar.tsx
@@ -1,26 +1,37 @@
 import { useState } from "react";
 import { TouchableOpacity, View, StyleSheet } from "react-native";
 import { Icon } from "react-native-paper";
+import UseTypeNavigation from "../../hooks/useTypeNavigation";
+import { RootStackParamList } from "../../types/navigation.types";
 
 export default function BottomNavBar() {
+  const navigation = UseTypeNavigation();
   const [currentScreen, setCurrentScreen] = useState("home");
 
-  const listOfButtons = [
+  const listOfButtons: {
+    icon: string;
+    screen: string;
+    navigationName: keyof RootStackParamList;
+  }[] = [
     {
       icon: "home-outline",
-      screen: "home"
+      screen: "home",
+      navigationName: "HomeScreen"
     },
     {
       icon: "heart-outline",
-      screen: "heart"
+      screen: "heart",
+      navigationName: "HomeScreen" // Change this later when the screen in created
     },
     {
       icon: "magnify",
-      screen: "explore"
+      screen: "explore",
+      navigationName: "ExploreScreen"
     },
     {
       icon: "cog-outline",
-      screen: "settings"
+      screen: "settings",
+      navigationName: "HomeScreen" // Change this later when the screen in created
     }
   ];
 
@@ -31,6 +42,7 @@ export default function BottomNavBar() {
           key={index}
           onPress={() => {
             setCurrentScreen(element.screen);
+            navigation.navigate(element.navigationName);
           }}
           style={
             currentScreen === element.screen

--- a/components/nav-bar/BottomNavBar.tsx
+++ b/components/nav-bar/BottomNavBar.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
 import { TouchableOpacity, View, StyleSheet } from "react-native";
 import { Icon } from "react-native-paper";
 import UseTypeNavigation from "../../hooks/useTypeNavigation";
 import { RootStackParamList } from "../../types/navigation.types";
+import { UseCurrentScreenStore } from "../../stores/useCurrentScreenStore";
 
 export default function BottomNavBar() {
   const navigation = UseTypeNavigation();
-  const [currentScreen, setCurrentScreen] = useState("home");
+  const { currentScreen, setCurrentScreen } = UseCurrentScreenStore();
 
   const listOfButtons: {
     icon: string;

--- a/hooks/useTypeNavigation.ts
+++ b/hooks/useTypeNavigation.ts
@@ -1,0 +1,6 @@
+import { NavigationProp, useNavigation } from "@react-navigation/native";
+import { RootStackParamList } from "../types/navigation.types";
+
+export default function UseTypeNavigation() {
+  return useNavigation<NavigationProp<RootStackParamList>>();
+}

--- a/navigation/navigation.tsx
+++ b/navigation/navigation.tsx
@@ -12,7 +12,8 @@ export default function RootStack() {
     <Stack.Navigator
       screenOptions={{
         headerShown: false,
-        contentStyle: { backgroundColor: "#061A1E" }
+        contentStyle: { backgroundColor: "#061A1E" },
+        animation: "none"
       }}
     >
       <Stack.Screen name="SigninScreen" component={SigninScreen} />

--- a/navigation/navigation.tsx
+++ b/navigation/navigation.tsx
@@ -3,6 +3,7 @@ import { RootStackParamList } from "../types/navigation.types";
 import SigninScreen from "../screens/SigninScreen";
 import HomeScreen from "../screens/HomeScreen";
 import CreateAccountScreen from "../screens/CreateAccountScreen";
+import ExploreScreen from "../screens/ExploreScreen";
 
 export default function RootStack() {
   const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -20,6 +21,7 @@ export default function RootStack() {
         name="CreateAccountScreen"
         component={CreateAccountScreen}
       />
+      <Stack.Screen name="ExploreScreen" component={ExploreScreen} />
     </Stack.Navigator>
   );
 }

--- a/screens/ExploreScreen.tsx
+++ b/screens/ExploreScreen.tsx
@@ -1,9 +1,18 @@
-import { View, Text } from "react-native";
+import { View, Text, StyleSheet } from "react-native";
+import BottomNavBar from "../components/nav-bar/BottomNavBar";
 
 export default function ExploreScreen() {
   return (
-    <View>
+    <View style={styles.container}>
       <Text>Explore screen</Text>
+      <BottomNavBar />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "space-between"
+  }
+});

--- a/screens/ExploreScreen.tsx
+++ b/screens/ExploreScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function ExploreScreen() {
+  return (
+    <View>
+      <Text>Explore screen</Text>
+    </View>
+  );
+}

--- a/stores/useCurrentScreenStore.ts
+++ b/stores/useCurrentScreenStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface ICurrentScreen {
+  currentScreen: string;
+  setCurrentScreen: (screen: string) => void;
+}
+
+export const UseCurrentScreenStore = create<ICurrentScreen>((set) => ({
+  currentScreen: "home",
+  setCurrentScreen: (screen) => set({ currentScreen: screen })
+}));

--- a/stores/useLocationStore.ts
+++ b/stores/useLocationStore.ts
@@ -1,14 +1,14 @@
 import { create } from "zustand";
 import * as Location from "expo-location";
 
-interface LocationState {
+interface ILocationState {
   location: Location.LocationObject | null;
   city: string | null;
   setLocation: (loc: Location.LocationObject) => void;
   setCity: (city: string) => void;
 }
 
-export const useLocationStore = create<LocationState>((set) => ({
+export const useLocationStore = create<ILocationState>((set) => ({
   location: null,
   city: null,
   setLocation: (location) => set({ location }),

--- a/stores/useUserStore.ts
+++ b/stores/useUserStore.ts
@@ -1,13 +1,13 @@
 import { create } from "zustand";
 import { IUserData } from "../types/IUserData";
 
-interface UserStore {
+interface IUserStore {
   userData: IUserData | null;
   setUserData: (data: IUserData) => void;
   clearUserData: () => void;
 }
 
-export const useUserStore = create<UserStore>((set) => ({
+export const useUserStore = create<IUserStore>((set) => ({
   userData: null,
   setUserData: (data) => set({ userData: data }),
   clearUserData: () => set({ userData: null })

--- a/types/navigation.types.ts
+++ b/types/navigation.types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   SigninScreen: undefined;
   HomeScreen: undefined;
   CreateAccountScreen: undefined;
+  ExploreScreen: undefined;
 };


### PR DESCRIPTION
In this PR: 

I created a explore screen and implemented all navigation to it thorugh BottomNavBar and on the 'explore all events' button in the concert list. I also created a Zustand Store for global 'currentScreen' state management

1. feat: add ExploreScreen and add it to navigation stack
2. feat: add navigation from concertList to explore screen
3. refactor: create typed useTypedNavigation hook for cleaner navigation usage.
4. feat: make navigation possible through BottomNavBar
5. feat: add BottomNavBar to ExploreScreen
6. feat: create zustand store for current screen
7. Refactor: add missing 'I' in the start of an interface name
8. Refactor: remove local currentScreen state in BottomNavBar and use the global currentScreen Zustand store instead
9. style: disable screen transition animations
10. feat: change currentScreen state when pressing Explore All Events