### PR TITLE
refactor: change-name-of-CreateAccountScreen-to-RegisterForm

### DIFF
--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -12,7 +12,7 @@ import { useSignup } from "../../hooks/useSignup";
 import { setUserDataFromFirebase } from "../../utils/setUserDataFromFirebase";
 import UseTypeNavigation from "../../hooks/useTypeNavigation";
 
-export default function CreateAccountForm({
+export default function RegisterForm({
   setSnackbarMsg,
   setIsSnackbarVisible
 }: {

--- a/components/forms/SigninForm.tsx
+++ b/components/forms/SigninForm.tsx
@@ -68,9 +68,7 @@ export default function SigninForm({
         <Text style={styles.smallText}>Forgot Password?</Text>
       </TouchableOpacity>
 
-      <TouchableOpacity
-        onPress={() => navigation.navigate("CreateAccountScreen")}
-      >
+      <TouchableOpacity onPress={() => navigation.navigate("RegisterScreen")}>
         <Text style={styles.smallText}>Create an account?</Text>
       </TouchableOpacity>
 

--- a/navigation/navigation.tsx
+++ b/navigation/navigation.tsx
@@ -2,8 +2,8 @@ import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { RootStackParamList } from "../types/navigation.types";
 import SigninScreen from "../screens/SigninScreen";
 import HomeScreen from "../screens/HomeScreen";
-import CreateAccountScreen from "../screens/CreateAccountScreen";
 import ExploreScreen from "../screens/ExploreScreen";
+import RegisterScreen from "../screens/RegisterScreen";
 
 export default function RootStack() {
   const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -18,10 +18,7 @@ export default function RootStack() {
     >
       <Stack.Screen name="SigninScreen" component={SigninScreen} />
       <Stack.Screen name="HomeScreen" component={HomeScreen} />
-      <Stack.Screen
-        name="CreateAccountScreen"
-        component={CreateAccountScreen}
-      />
+      <Stack.Screen name="RegisterScreen" component={RegisterScreen} />
       <Stack.Screen name="ExploreScreen" component={ExploreScreen} />
     </Stack.Navigator>
   );

--- a/screens/RegisterScreen.tsx
+++ b/screens/RegisterScreen.tsx
@@ -10,9 +10,9 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Snackbar } from "react-native-paper";
 import { useState } from "react";
 import { StatusBar } from "react-native";
-import CreateAccountForm from "../components/forms/CreateAccountForm";
+import RegisterForm from "../components/forms/RegisterForm";
 
-export default function CreateAccountScreen() {
+export default function RegisterScreen() {
   const [isSnackbarVisible, setIsSnackbarVisible] = useState<boolean>(false);
   const onDismissSnackBar = () => setIsSnackbarVisible(false);
   const [snackbarMsg, setSnackbarMsg] = useState<string | null>(null);
@@ -31,7 +31,7 @@ export default function CreateAccountScreen() {
             style={styles.logo}
             resizeMode="contain"
           />
-          <CreateAccountForm
+          <RegisterForm
             setSnackbarMsg={setSnackbarMsg}
             setIsSnackbarVisible={setIsSnackbarVisible}
           />

--- a/types/navigation.types.ts
+++ b/types/navigation.types.ts
@@ -1,6 +1,6 @@
 export type RootStackParamList = {
   SigninScreen: undefined;
   HomeScreen: undefined;
-  CreateAccountScreen: undefined;
+  RegisterScreen: undefined;
   ExploreScreen: undefined;
 };


### PR DESCRIPTION
In this PR: 

Felt like the name CreateAccountScreen, CreateAccountForm etc. was to long so changed it to RegisterScreen, RegisterForm etc.

1. refactor: change name of CreateAccountScreen to RegisterForm