### PR TITLE
Feature/quick-filters

### DIFF
--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -20,10 +20,14 @@ export async function searchConcertsByCountry(
   countryCode: string,
   page: number,
   size: number,
-  genreName?: IGenreName
+  genreNames?: IGenreName[]
 ): Promise<ITicketmasterSearchResponse> {
   const genreIdParam =
-    genreName !== undefined ? `&classificationId=${genreIdMap[genreName]}` : "";
+    genreNames && genreNames.length > 0
+      ? `&classificationId=${genreNames
+          .map((name) => genreIdMap[name])
+          .join(",")}`
+      : "";
 
   return await Get<ITicketmasterSearchResponse>(
     `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&countryCode=${countryCode}&size=${size}&page=${page}${genreIdParam}`

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -7,12 +7,19 @@ import { IGenreName } from "../types/IGenreName";
 export async function searchConcertsByCity(
   city: string,
   size: number,
-  page?: number
+  page?: number,
+  genreNames?: IGenreName[]
 ): Promise<ITicketmasterSearchResponse> {
   const pageParam = page !== undefined ? `&page=${page}` : "";
+  const genreIdParam =
+    genreNames && genreNames.length > 0
+      ? `&classificationId=${genreNames
+          .map((name) => genreIdMap[name])
+          .join(",")}`
+      : "";
 
   return await Get<ITicketmasterSearchResponse>(
-    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&city=${city}&size=${size}${pageParam}`
+    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&city=${city}&size=${size}${pageParam}${genreIdParam}`
   ).then(({ data }) => data);
 }
 

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -1,6 +1,8 @@
 import { APIConfig } from "./APIConfig";
 import { Get } from "./APIUtils";
 import { ITicketmasterSearchResponse } from "../types/ITicketmasterEvent";
+import { genreIdMap } from "../constants/genreIdMap";
+import { IGenreName } from "../types/IGenreName";
 
 export async function searchConcertsByCity(
   city: string,
@@ -17,9 +19,13 @@ export async function searchConcertsByCity(
 export async function searchConcertsByCountry(
   countryCode: string,
   page: number,
-  size: number
+  size: number,
+  genreName?: IGenreName
 ): Promise<ITicketmasterSearchResponse> {
+  const genreIdParam =
+    genreName !== undefined ? `&classificationId=${genreIdMap[genreName]}` : "";
+
   return await Get<ITicketmasterSearchResponse>(
-    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&countryCode=${countryCode}&size=${size}&page=${page}`
+    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&countryCode=${countryCode}&size=${size}&page=${page}${genreIdParam}`
   ).then(({ data }) => data);
 }

--- a/components/filter/FilterChipBar.tsx
+++ b/components/filter/FilterChipBar.tsx
@@ -19,7 +19,7 @@ export default function FilterChipBar({
       icon: "calendar-today"
     },
     {
-      name: "Pop",
+      name: "HipHop",
       icon: "party-popper"
     },
     {

--- a/components/lists/ConcertGrid.tsx
+++ b/components/lists/ConcertGrid.tsx
@@ -47,7 +47,8 @@ export default function ConcertGrid({ selectedFilters }: ConcertGridProps) {
         return await searchConcertsByCountry(
           countryCode,
           pageParam as number,
-          10
+          10,
+          "Pop" // ! Test
         );
       }
     }

--- a/components/lists/ConcertGrid.tsx
+++ b/components/lists/ConcertGrid.tsx
@@ -38,7 +38,17 @@ export default function ConcertGrid({ selectedFilters }: ConcertGridProps) {
         if (!city) {
           throw new Error("Missing city ");
         }
-        return await searchConcertsByCity(city, 10, pageParam as number);
+
+        const genreFilters = selectedFilters.filter((f): f is Genre =>
+          AVAILABLE_GENRES.includes(f as Genre)
+        );
+
+        return await searchConcertsByCity(
+          city,
+          10,
+          pageParam as number,
+          genreFilters
+        );
       } else {
         if (!countryCode) {
           throw new Error("Missing country code");

--- a/components/lists/ConcertGrid.tsx
+++ b/components/lists/ConcertGrid.tsx
@@ -11,6 +11,7 @@ import { ITicketmasterSearchResponse } from "../../types/ITicketmasterEvent";
 import { IConcertCard } from "../../types/IConcertCard";
 import { ActivityIndicator } from "react-native-paper";
 import { IGenreName } from "../../types/IGenreName";
+import { deduplicateConcerts } from "../../utils/deduplicateConcerts";
 
 interface ConcertGridProps {
   selectedFilters: string[];
@@ -68,22 +69,11 @@ export default function ConcertGrid({ selectedFilters }: ConcertGridProps) {
     }
   });
 
-  const allConcerts: IConcertCard[] =
-    concertList?.pages
-      .flatMap((page) => (page._embedded?.events ?? []).map(mapToConcertCard))
-      .reduce<IConcertCard[]>((acc, current) => {
-        const exists = acc.some(
-          (c) =>
-            c.artist === current.artist &&
-            new Date(c.date).toDateString() ===
-              new Date(current.date).toDateString()
-        );
-        if (!exists) acc.push(current);
-        return acc;
-      }, [])
-      .sort(
-        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
-      ) ?? [];
+  const allConcerts: IConcertCard[] = deduplicateConcerts(
+    concertList?.pages.flatMap((page) =>
+      (page._embedded?.events ?? []).map(mapToConcertCard)
+    ) ?? []
+  );
 
   const handleEndReached = () => {
     if (hasNextPage) {

--- a/components/lists/ConcertGrid.tsx
+++ b/components/lists/ConcertGrid.tsx
@@ -10,7 +10,6 @@ import ConcertCard from "../cards/ConcertCard";
 import { ITicketmasterSearchResponse } from "../../types/ITicketmasterEvent";
 import { IConcertCard } from "../../types/IConcertCard";
 import { ActivityIndicator } from "react-native-paper";
-import { useEffect } from "react";
 import { IGenreName } from "../../types/IGenreName";
 
 interface ConcertGridProps {
@@ -72,6 +71,16 @@ export default function ConcertGrid({ selectedFilters }: ConcertGridProps) {
   const allConcerts: IConcertCard[] =
     concertList?.pages
       .flatMap((page) => (page._embedded?.events ?? []).map(mapToConcertCard))
+      .reduce<IConcertCard[]>((acc, current) => {
+        const exists = acc.some(
+          (c) =>
+            c.artist === current.artist &&
+            new Date(c.date).toDateString() ===
+              new Date(current.date).toDateString()
+        );
+        if (!exists) acc.push(current);
+        return acc;
+      }, [])
       .sort(
         (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
       ) ?? [];

--- a/components/lists/ConcertGrid.tsx
+++ b/components/lists/ConcertGrid.tsx
@@ -10,8 +10,9 @@ import ConcertCard from "../cards/ConcertCard";
 import { ITicketmasterSearchResponse } from "../../types/ITicketmasterEvent";
 import { IConcertCard } from "../../types/IConcertCard";
 import { ActivityIndicator } from "react-native-paper";
-import { IGenreName } from "../../types/IGenreName";
 import { deduplicateConcerts } from "../../utils/deduplicateConcerts";
+import { getNextPageParam } from "../../utils/getNextPageParam";
+import { AVAILABLE_GENRES, Genre } from "../../constants/genres";
 
 interface ConcertGridProps {
   selectedFilters: string[];
@@ -31,11 +32,7 @@ export default function ConcertGrid({ selectedFilters }: ConcertGridProps) {
     queryKey: ["concerts", countryCode, isNearbySelected, selectedFilters],
     enabled: !!countryCode,
     initialPageParam: 0,
-    getNextPageParam: (lastPage, pages) => {
-      const currentPage = lastPage.page?.number ?? pages.length - 1;
-      const totalPages = lastPage.page?.totalPages ?? 0;
-      return currentPage + 1 < totalPages ? currentPage + 1 : undefined;
-    },
+    getNextPageParam,
     queryFn: async ({ pageParam = 0 }) => {
       if (isNearbySelected) {
         if (!city) {
@@ -47,16 +44,8 @@ export default function ConcertGrid({ selectedFilters }: ConcertGridProps) {
           throw new Error("Missing country code");
         }
 
-        const genreFilters = selectedFilters.filter((f): f is IGenreName =>
-          [
-            "Pop",
-            "Country",
-            "Electronic",
-            "Rock",
-            "HipHop",
-            "Jazz",
-            "Classical"
-          ].includes(f as IGenreName)
+        const genreFilters = selectedFilters.filter((f): f is Genre =>
+          AVAILABLE_GENRES.includes(f as Genre)
         );
 
         return await searchConcertsByCountry(

--- a/constants/genreIdMap.ts
+++ b/constants/genreIdMap.ts
@@ -1,0 +1,11 @@
+import { IGenreName } from "../types/IGenreName";
+
+export const genreIdMap: Record<IGenreName, string> = {
+  Rock: "KnvZfZ7vAeA",
+  Pop: "KnvZfZ7vAev",
+  Country: "KnvZfZ7vAe6",
+  HipHop: "KnvZfZ7vAv1",
+  Jazz: "KnvZfZ7vAvE",
+  Classical: "KnvZfZ7vAeJ",
+  Electronic: "KnvZfZ7vAvF"
+};

--- a/constants/genres.ts
+++ b/constants/genres.ts
@@ -1,0 +1,10 @@
+export const AVAILABLE_GENRES = [
+  "Pop",
+  "Country",
+  "Electronic",
+  "Rock",
+  "HipHop",
+  "Jazz",
+  "Classical"
+] as const;
+export type Genre = (typeof AVAILABLE_GENRES)[number];

--- a/types/IGenreName.ts
+++ b/types/IGenreName.ts
@@ -1,0 +1,8 @@
+export type IGenreName =
+  | "Pop"
+  | "Country"
+  | "Electronic"
+  | "Rock"
+  | "HipHop"
+  | "Jazz"
+  | "Classical";

--- a/utils/deduplicateConcerts.ts
+++ b/utils/deduplicateConcerts.ts
@@ -1,0 +1,16 @@
+import { IConcertCard } from "../types/IConcertCard";
+
+export function deduplicateConcerts(concerts: IConcertCard[]): IConcertCard[] {
+  return concerts
+    .reduce<IConcertCard[]>((acc, current) => {
+      const exists = acc.some(
+        (c) =>
+          c.artist === current.artist &&
+          new Date(c.date).toDateString() ===
+            new Date(current.date).toDateString()
+      );
+      if (!exists) acc.push(current);
+      return acc;
+    }, [])
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}

--- a/utils/getNextPageParam.ts
+++ b/utils/getNextPageParam.ts
@@ -1,0 +1,10 @@
+import { ITicketmasterSearchResponse } from "../types/ITicketmasterEvent";
+
+export const getNextPageParam = (
+  lastPage: ITicketmasterSearchResponse,
+  pages: ITicketmasterSearchResponse[]
+): number | undefined => {
+  const currentPage = lastPage.page?.number ?? pages.length - 1;
+  const totalPages = lastPage.page?.totalPages ?? 0;
+  return currentPage + 1 < totalPages ? currentPage + 1 : undefined;
+};


### PR DESCRIPTION
In this PR: 

This PR make it possible for users to filter through genres in the 'quick' filters bar in ExploreScreen and choose to see nearby events in the city they are currently in.

1. feat: add ability to pass genre as a param to searchConcertByCountry.
2. feat: implement functional quick genre filtering and the ability to pass multiple genres to filter.
3. feat: remove duplicate concerts on same date
4. refactor: broke out deduplicateConcert function to its on file.
5. refactor: broke out genres to a conctants file, broke out getNextPageParam to its own utility function.
6. feat: add ability to filter through genres with searchConcertsByCity