### PR TITLE
Feature/add-'today'-filter-logic-so-the-filter-works

### DIFF
--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -3,14 +3,17 @@ import { Get } from "./APIUtils";
 import { ITicketmasterSearchResponse } from "../types/ITicketmasterEvent";
 import { genreIdMap } from "../constants/genreIdMap";
 import { IGenreName } from "../types/IGenreName";
+import { getTodayDateRange } from "../utils/getTodaysDateRange";
 
 export async function searchConcertsByCity(
   city: string,
   size: number,
   page?: number,
-  genreNames?: IGenreName[]
+  genreNames?: IGenreName[],
+  onlyToday: boolean = false
 ): Promise<ITicketmasterSearchResponse> {
   const pageParam = page !== undefined ? `&page=${page}` : "";
+
   const genreIdParam =
     genreNames && genreNames.length > 0
       ? `&classificationId=${genreNames
@@ -18,8 +21,10 @@ export async function searchConcertsByCity(
           .join(",")}`
       : "";
 
+  const dateRangeParam = getTodayDateRange(onlyToday);
+
   return await Get<ITicketmasterSearchResponse>(
-    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&city=${city}&size=${size}${pageParam}${genreIdParam}&sort=date,asc`
+    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&city=${city}&size=${size}${pageParam}${genreIdParam}&sort=date,asc${dateRangeParam}`
   ).then(({ data }) => data);
 }
 
@@ -27,7 +32,8 @@ export async function searchConcertsByCountry(
   countryCode: string,
   page: number,
   size: number,
-  genreNames?: IGenreName[]
+  genreNames?: IGenreName[],
+  onlyToday: boolean = false
 ): Promise<ITicketmasterSearchResponse> {
   const genreIdParam =
     genreNames && genreNames.length > 0
@@ -36,7 +42,9 @@ export async function searchConcertsByCountry(
           .join(",")}`
       : "";
 
+  const dateRangeParam = getTodayDateRange(onlyToday);
+
   return await Get<ITicketmasterSearchResponse>(
-    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&countryCode=${countryCode}&size=${size}&page=${page}${genreIdParam}&sort=date,asc`
+    `${APIConfig.searchEvents}${APIConfig.key}&classificationName=music&countryCode=${countryCode}&size=${size}&page=${page}${genreIdParam}&sort=date,asc${dateRangeParam}`
   ).then(({ data }) => data);
 }

--- a/utils/fetchConcerts.ts
+++ b/utils/fetchConcerts.ts
@@ -23,16 +23,27 @@ export const fetchConcerts = async ({
     AVAILABLE_GENRES.includes(f as Genre)
   );
 
+  const isTodaySelected = selectedFilters.includes("Today");
+
   if (isNearbySelected) {
     if (!city) throw new Error("Missing city");
-    return await searchConcertsByCity(city, 10, pageParam, genreFilters);
+
+    return await searchConcertsByCity(
+      city,
+      10,
+      pageParam,
+      genreFilters,
+      isTodaySelected
+    );
   }
 
   if (!countryCode) throw new Error("Missing country code");
+
   return await searchConcertsByCountry(
     countryCode,
     pageParam,
     10,
-    genreFilters
+    genreFilters,
+    isTodaySelected
   );
 };

--- a/utils/getTodaysDateRange.ts
+++ b/utils/getTodaysDateRange.ts
@@ -1,0 +1,9 @@
+export function getTodayDateRange(onlyToday: boolean) {
+  const today = new Date();
+  const todayDate = today.toISOString().split("T")[0];
+  const startOfToday = `${todayDate}T00:00:00Z`;
+  const endOfToday = `${todayDate}T23:59:59Z`;
+
+  const timeParams = `&startDateTime=${startOfToday}`;
+  return onlyToday ? `${timeParams}&endDateTime=${endOfToday}` : timeParams;
+}


### PR DESCRIPTION
In this PR:

In this PR i added logic to the 'today' quick filter. When you press the 'today' filter, only events with todays date will be fetched and rendered. I also implemented a standars start fetch date to eliminate fetching of events in the past.

1. add 'today' filter logic so the filter works.