### PR TITLE
Chore/cleanup-refactor-api-methods

### DIFF
--- a/api/APIConfig.ts
+++ b/api/APIConfig.ts
@@ -1,11 +1,15 @@
 export const APIConfig = {
   base_url: "https://app.ticketmaster.com/discovery/v2",
   key: "y8iKP66q9ygMnQZ8RRJnCeCDjPALHaEe",
-  searchEvents: "/events.json?apikey=",
+
+  events: {
+    search: "/events.json?apikey="
+  },
 
   eventType: {
     music: "&classificationName=music"
   },
+
   fetchOrder: {
     ascending: "&sort=date,asc"
   }

--- a/api/APIConfig.ts
+++ b/api/APIConfig.ts
@@ -1,5 +1,12 @@
 export const APIConfig = {
   base_url: "https://app.ticketmaster.com/discovery/v2",
   key: "y8iKP66q9ygMnQZ8RRJnCeCDjPALHaEe",
-  searchEvents: "/events.json?apikey="
+  searchEvents: "/events.json?apikey=",
+
+  eventType: {
+    music: "&classificationName=music"
+  },
+  fetchOrder: {
+    ascending: "&sort=date,asc"
+  }
 };

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -15,14 +15,14 @@ async function searchConcertsBase({
   size,
   page,
   genreNames,
-  onlyToday,
+  isOnlyToday,
   keyword
 }: {
   locationParam: string;
   size: number;
   page?: number;
   genreNames?: IGenreName[];
-  onlyToday?: boolean;
+  isOnlyToday: boolean;
   keyword?: string;
 }): Promise<ITicketmasterSearchResponse> {
   const query = [
@@ -35,7 +35,7 @@ async function searchConcertsBase({
     buildPageParam(page),
     buildGenreParam(genreNames),
     buildKeywordParam(keyword),
-    getTodayDateRange(!!onlyToday)
+    getTodayDateRange(isOnlyToday)
   ].join("");
 
   return await Get<ITicketmasterSearchResponse>(query).then(({ data }) => data);
@@ -46,7 +46,7 @@ export function searchConcertsByCity(
   size: number,
   page?: number,
   genreNames?: IGenreName[],
-  onlyToday: boolean = false,
+  isOnlyToday: boolean = false,
   keyword?: string
 ) {
   return searchConcertsBase({
@@ -54,7 +54,7 @@ export function searchConcertsByCity(
     size,
     page,
     genreNames,
-    onlyToday,
+    isOnlyToday,
     keyword
   });
 }
@@ -64,7 +64,7 @@ export function searchConcertsByCountry(
   page: number,
   size: number,
   genreNames?: IGenreName[],
-  onlyToday: boolean = false,
+  isOnlyToday: boolean = false,
   keyword?: string
 ) {
   return searchConcertsBase({
@@ -72,7 +72,7 @@ export function searchConcertsByCountry(
     size,
     page,
     genreNames,
-    onlyToday,
+    isOnlyToday,
     keyword
   });
 }

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -25,14 +25,15 @@ async function searchConcertsBase({
   keyword?: string;
 }): Promise<ITicketmasterSearchResponse> {
   const query = [
-    `${APIConfig.searchEvents}${APIConfig.key}`,
-    "&classificationName=music", // ! move this to default
+    APIConfig.searchEvents,
+    APIConfig.key,
+    APIConfig.eventType.music,
+    APIConfig.fetchOrder.ascending,
     locationParam,
     `&size=${size}`,
     buildPageParam(page),
     buildGenreParam(genreNames),
     buildKeywordParam(keyword),
-    "&sort=date,asc", // ! move this to default
     getTodayDateRange(!!onlyToday)
   ].join("");
 

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -26,7 +26,7 @@ async function searchConcertsBase({
   keyword?: string;
 }): Promise<ITicketmasterSearchResponse> {
   const query = [
-    APIConfig.searchEvents,
+    APIConfig.events.search,
     APIConfig.key,
     APIConfig.eventType.music,
     APIConfig.fetchOrder.ascending,

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -3,7 +3,11 @@ import { Get } from "./APIUtils";
 import { ITicketmasterSearchResponse } from "../types/ITicketmasterEvent";
 import { IGenreName } from "../types/IGenreName";
 import { getTodayDateRange } from "../utils/getTodaysDateRange";
-import { buildGenreParam, buildPageParam } from "../utils/buildQueryParams";
+import {
+  buildGenreParam,
+  buildKeywordParam,
+  buildPageParam
+} from "../utils/buildQueryParams";
 
 async function searchConcertsBase({
   locationParam,
@@ -22,13 +26,13 @@ async function searchConcertsBase({
 }): Promise<ITicketmasterSearchResponse> {
   const query = [
     `${APIConfig.searchEvents}${APIConfig.key}`,
-    "&classificationName=music",
+    "&classificationName=music", // ! move this to default
     locationParam,
     `&size=${size}`,
     buildPageParam(page),
     buildGenreParam(genreNames),
-    keyword ? `&keyword=${encodeURIComponent(keyword)}` : "",
-    "&sort=date,asc",
+    buildKeywordParam(keyword),
+    "&sort=date,asc", // ! move this to default
     getTodayDateRange(!!onlyToday)
   ].join("");
 

--- a/api/APIMethods.ts
+++ b/api/APIMethods.ts
@@ -6,7 +6,8 @@ import { getTodayDateRange } from "../utils/getTodaysDateRange";
 import {
   buildGenreParam,
   buildKeywordParam,
-  buildPageParam
+  buildPageParam,
+  buildSizeParam
 } from "../utils/buildQueryParams";
 
 async function searchConcertsBase({
@@ -30,7 +31,7 @@ async function searchConcertsBase({
     APIConfig.eventType.music,
     APIConfig.fetchOrder.ascending,
     locationParam,
-    `&size=${size}`,
+    buildSizeParam(size),
     buildPageParam(page),
     buildGenreParam(genreNames),
     buildKeywordParam(keyword),

--- a/utils/buildQueryParams.ts
+++ b/utils/buildQueryParams.ts
@@ -15,3 +15,7 @@ export function buildPageParam(page?: number) {
 export function buildKeywordParam(keyword?: string) {
   return keyword !== undefined ? `&keyword=${keyword}` : "";
 }
+
+export function buildSizeParam(size: number) {
+  return `&size=${size}`;
+}

--- a/utils/buildQueryParams.ts
+++ b/utils/buildQueryParams.ts
@@ -11,3 +11,7 @@ export function buildGenreParam(genreNames?: IGenreName[]) {
 export function buildPageParam(page?: number) {
   return page !== undefined ? `&page=${page}` : "";
 }
+
+export function buildKeywordParam(keyword?: string) {
+  return keyword !== undefined ? `&keyword=${keyword}` : "";
+}


### PR DESCRIPTION
In this PR:

1. refactor: move keyword param to BuildKeywordParam function.
2. refactor: move eventType and fetchOrder endpoints to APIConfig.
3. refactor: move size param to buildSizeParam function.
4. refactor: change name of eventSearch endpoint in APIConfig.
5. chore: remove optional from isOnlyToday parameter.