### PR TITLE
Feature/show-'TBA'-if-no-artist-name-is-avalible

### DIFF
--- a/components/cards/ConcertCard.tsx
+++ b/components/cards/ConcertCard.tsx
@@ -57,7 +57,7 @@ export default function ConcertCard({
         </TouchableOpacity>
         <Card.Content style={styles.cardText}>
           <Text style={styles.cardTitle}>
-            {concert._embedded?.attractions?.[0].name}
+            {concert._embedded?.attractions?.[0].name ?? "TBA"}
           </Text>
           <Text style={styles.cardSubtitle}>
             {concert._embedded?.venues?.[0].city?.name}


### PR DESCRIPTION
In this PR: 

If artist name is undefined, show 'TBA' in the concert card

1. feat: show 'TBA' if no artist name is avalible