### PR TITLE
Feature/add-concert-to-calender-using-expo-calender

### DIFF
--- a/components/modals/ConcertDetailsModal.tsx
+++ b/components/modals/ConcertDetailsModal.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView
 } from "react-native";
 import { ITicketmasterEvent } from "../../types/ITicketmasterEvent";
+import { addConcertToCalendar } from "../../utils/addConcertToCalender";
 
 interface ConcertDetailsModalProps {
   visible: boolean;
@@ -76,6 +77,15 @@ export default function ConcertDetailsModal({
                 concert.pleaseNote ||
                 "No additional information available."}
             </Text>
+
+            <Button
+              mode="outlined"
+              onPress={() => addConcertToCalendar(concert)}
+              style={{ marginTop: 10, borderColor: "#F77E32" }}
+              labelStyle={{ color: "#F77E32" }}
+            >
+              Add to Calendar
+            </Button>
 
             <Button
               mode="contained"

--- a/components/modals/ConcertDetailsModal.tsx
+++ b/components/modals/ConcertDetailsModal.tsx
@@ -48,11 +48,14 @@ export default function ConcertDetailsModal({
 
           <View style={styles.timeAndPlace}>
             <Text style={styles.label}>
-              {concert._embedded?.venues?.[0]?.name}
+              {concert._embedded?.venues?.[0]?.name ??
+                "Venue name is currently unavailable"}
             </Text>
             <View style={{ flexDirection: "row", gap: 5 }}>
               <Text style={styles.label}>
-                {concert._embedded?.venues?.[0]?.city?.name},
+                {concert._embedded?.venues?.[0]?.city?.name ??
+                  "City is currently unavailable"}
+                ,
               </Text>
 
               <Text style={styles.label}>
@@ -81,7 +84,7 @@ export default function ConcertDetailsModal({
             <Button
               mode="outlined"
               onPress={() => addConcertToCalendar(concert)}
-              style={{ marginTop: 10, borderColor: "#F77E32" }}
+              style={styles.calenderButton}
               labelStyle={{ color: "#F77E32" }}
             >
               Add to Calendar
@@ -144,5 +147,6 @@ const styles = StyleSheet.create({
     paddingVertical: 5,
     paddingHorizontal: 10,
     alignItems: "center"
-  }
+  },
+  calenderButton: { marginTop: 10, borderColor: "#F77E32" }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tanstack/react-query": "^5.75.5",
         "axios": "^1.9.0",
         "expo": "~52.0.46",
+        "expo-calendar": "~14.0.6",
         "expo-linear-gradient": "~14.0.2",
         "expo-location": "~18.0.10",
         "expo-status-bar": "~2.0.1",
@@ -6699,6 +6700,16 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-calendar": {
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/expo-calendar/-/expo-calendar-14.0.6.tgz",
+      "integrity": "sha512-aOby7ueR8lB9sWTHXkECZiPDZNVRsGQYhJTe05puNZicMWCV4c53Z/LRiCTTq3LBXV4zpBOB5rXiCyA1f082yA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-native-paper": "^5.14.0",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
-    "zustand": "^5.0.4"
+    "zustand": "^5.0.4",
+    "expo-calendar": "~14.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/utils/addConcertToCalender.ts
+++ b/utils/addConcertToCalender.ts
@@ -1,0 +1,39 @@
+import * as Calendar from "expo-calendar";
+import { ITicketmasterEvent } from "../types/ITicketmasterEvent";
+import { Alert } from "react-native";
+
+export async function addConcertToCalendar(concert: ITicketmasterEvent) {
+  const { status } = await Calendar.requestCalendarPermissionsAsync();
+  if (status !== "granted") {
+    Alert.alert("Error", "Permission to access calendar was denied");
+    return;
+  }
+
+  const calendars = await Calendar.getCalendarsAsync(
+    Calendar.EntityTypes.EVENT
+  );
+  const defaultCalendar = calendars.find((cal) => cal.allowsModifications);
+
+  if (!defaultCalendar) {
+    alert("No calendar found.");
+    return;
+  }
+
+  const startDate = new Date(
+    `${concert.dates.start.localDate}T${
+      concert.dates.start.localTime ?? "12:00"
+    }`
+  );
+  const endDate = new Date(startDate.getTime() + 2 * 60 * 60 * 1000);
+
+  await Calendar.createEventAsync(defaultCalendar.id, {
+    title: concert.name,
+    startDate,
+    endDate,
+    timeZone: "local",
+    location: concert._embedded?.venues?.[0]?.name,
+    notes: "Event added from GigRadar. Check ticket site for more details."
+  });
+
+  Alert.alert("Success!", "Concert added to your calendar!");
+}


### PR DESCRIPTION
In this PR: 

1. feat: implement expo-calender and make it possible to save concerts to phone calendar.
2. refactor: move inline styling to stylesheet in ConcertDetailsModal.